### PR TITLE
Make the GenericControlBinder actually generic.

### DIFF
--- a/Binding/ControlBinders/ControlBinderBase.cs
+++ b/Binding/ControlBinders/ControlBinderBase.cs
@@ -11,6 +11,7 @@ namespace ControlBinding.ControlBinders
         internal BindingConfiguration _bindingConfiguration;
 
         public bool IsBound { get; set; }
+        public int Priority => 1;
 
         public virtual void BindControl(BindingConfiguration bindingConfiguration)
         {

--- a/Binding/ControlBinders/ControlBinderProvider.cs
+++ b/Binding/ControlBinders/ControlBinderProvider.cs
@@ -20,7 +20,9 @@ namespace ControlBinding.ControlBinders
 
         public IControlBinder GetBinder(object sourceObject)
         {
-            var binder = _binders.FirstOrDefault(x => x.CanBindFor(sourceObject));
+            var binder = _binders.Where(x => x.CanBindFor(sourceObject))
+                .OrderByDescending(x => x.Priority)
+                .FirstOrDefault();
 
             if (binder == null)
             {

--- a/Binding/ControlBinders/GenericControlBinder.cs
+++ b/Binding/ControlBinders/GenericControlBinder.cs
@@ -6,9 +6,10 @@ namespace ControlBinding.ControlBinders;
 
 public partial class GenericControlBinder : ControlBinderBase
 {
+    public new int Priority => 0;
     public override bool CanBindFor(object control)
     {
-        return control is Label || control is Button;
+        return control is Godot.Control;
     }
 
     public override void ClearEventBindings()

--- a/Binding/Interfaces/IControlBinder.cs
+++ b/Binding/Interfaces/IControlBinder.cs
@@ -10,4 +10,5 @@ public interface IControlBinder
     void OnObservableListChanged(ObservableListChangedEventArgs eventArgs);
     void ClearEventBindings();
     bool IsBound { get; set; }
+    public int Priority { get; }
 }


### PR DESCRIPTION
ControlBinders are ordered by priority to grab more specific binders first