### PR TITLE
Add limited TwoWay scene list binding

### DIFF
--- a/Binding/Collections/IObservableList.cs
+++ b/Binding/Collections/IObservableList.cs
@@ -7,4 +7,5 @@ public interface IObservableList
     public IList<object> GetBackingList();
     void OnObservableListChanged(ObservableListChangedEventArgs eventArgs);
     event ObservableListChangedEventHandler ObservableListChanged;
+    void RemoveAt(int index);
 }

--- a/Binding/Collections/ObservableList.cs
+++ b/Binding/Collections/ObservableList.cs
@@ -96,7 +96,7 @@ public partial class ObservableList<T> : ObservableObject, IList<T>, IObservable
 
     public void RemoveAt(int index)
     {
-        if (index >= 0 && index < _backingList.Count - 1)
+        if (index >= 0 && index <= _backingList.Count - 1)
         {
             var removedItem = _backingList[index];
             _backingList.RemoveAt(index);

--- a/Binding/ControlBinders/ControlBinderBase.cs
+++ b/Binding/ControlBinders/ControlBinderBase.cs
@@ -12,6 +12,13 @@ namespace Godot.Community.ControlBinding.ControlBinders
             ControlValueChanged?.Invoke(control, propertyName);
         }
 
+        public delegate void ControlChildListChangedEventHandler(Godot.Control control, ObservableListChangedEventArgs args);
+        public event ControlChildListChangedEventHandler ControlChildListChanged;
+        public void OnControlChildListChanged(Godot.Control control, ObservableListChangedEventArgs args)
+        {
+            ControlChildListChanged?.Invoke(control, args);
+        }
+
         internal BindingConfiguration _bindingConfiguration;
 
         public bool IsBound { get; set; }

--- a/Binding/ControlBinders/GenericControlBinder.cs
+++ b/Binding/ControlBinders/GenericControlBinder.cs
@@ -19,7 +19,7 @@ public partial class GenericControlBinder : ControlBinderBase
         if (bindingConfiguration.BoundControl.Target is Godot.Control controlInstance)
             _boundControl = controlInstance;
 
-        if (bindingConfiguration.IsListBinding)
+        if (bindingConfiguration.IsListBinding && bindingConfiguration.BindingMode == BindingMode.TwoWay)
         {
             _boundControl.ChildExitingTree += OnChildExitingTree;
         }

--- a/Binding/ControlBinders/GenericControlBinder.cs
+++ b/Binding/ControlBinders/GenericControlBinder.cs
@@ -72,7 +72,10 @@ public partial class GenericControlBinder : ControlBinderBase
 
     public override void ClearEventBindings()
     {
-        throw new NotImplementedException();
+        if(_bindingConfiguration.BindingMode == BindingMode.TwoWay)
+        {
+            _boundControl.ChildExitingTree -= OnChildExitingTree;
+        }
     }
 
     public override IControlBinder CreateInstance()

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If any objects along the path are updated, the binding will be refreshed. Object
 ### Scene list binding
 Bind a `ObservableList<T>` to any control and provide a scene to instiate as child nodes. Modifications (add/remove) are reflected in the control's child list.
 
+Scene list bindings have limited TwoWay binding support. Child items removed from the tree will also be removed from the bound list.
+
 ![scenelist](https://github.com/Dangles91/Godot.Community.ControlBinding/assets/9249458/58e270db-6af6-492b-8403-477dc8d63c9d)
 
 ## :toolbox: Usage

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Bind a `ObservableList<T>` to any control and provide a scene to instiate as chi
 
 Scene list bindings have limited TwoWay binding support. Child items removed from the tree will also be removed from the bound list.
 
-![scenelist](https://github.com/Dangles91/Godot.Community.ControlBinding/assets/9249458/58e270db-6af6-492b-8403-477dc8d63c9d)
+![Animation](https://github.com/Dangles91/Godot.Community.ControlBinding/assets/9249458/8c21a527-8326-4ace-b4b3-8035b6c25ac6)
 
 ## :toolbox: Usage
 The main components of control binding are the `ObservableObject` and `ObservableNode` classes which implement a `PropertyChanged` event and `OnPropertyChanged` method.
@@ -66,8 +66,6 @@ The main components of control binding are the `ObservableObject` and `Observabl
 The script which backs your scene must inherit from `ObservableNode`. Other observable objects that are not added to the scene tree should inherit from `ObservableObject`. This prevents orphaned nodes.
 
 See the ![example project](/examples/basic-bindings) for some bindings in action!
-
-![image](https://github.com/Dangles91/Godot.Community.ControlBinding/assets/9249458/e0071bff-133a-4b49-be7d-7dfefd84616e)
 
 
 ### Property binding

--- a/examples/basic-bindings/Control.cs
+++ b/examples/basic-bindings/Control.cs
@@ -78,7 +78,7 @@ public partial class Control : ObservableNode
         BindListProperty("%ItemList3", $"{nameof(SelectedPlayerData)}.{nameof(PlayerData.ListOfThings)}", BindingMode.TwoWay);
 
         BindEnumProperty<BindingMode>("%OptionButton", $"{nameof(SelectedPlayerData)}.{nameof(SelectedPlayerData.BindingMode)}");
-        BindSceneList("%VBoxContainer", nameof(playerDatas), "uid://die1856ftg8w8");
+        BindSceneList("%VBoxContainer", nameof(playerDatas), "uid://die1856ftg8w8", BindingMode.TwoWay);
 
         base._Ready();
     }

--- a/examples/basic-bindings/PlayerDataListItem.cs
+++ b/examples/basic-bindings/PlayerDataListItem.cs
@@ -1,28 +1,31 @@
 using ControlBinding;
 using Godot;
 using Godot.Community.ControlBinding;
-using System;
 
 public partial class PlayerDataListItem : ObservableNode
 {
 
-	private PlayerData ViewModelData { get; set; }
+    private PlayerData ViewModelData { get; set; }
 
     public override void SetViewModelData(object viewModelData)
     {
-		ViewModelData = viewModelData as PlayerData;
+        ViewModelData = viewModelData as PlayerData;
         base.SetViewModelData(viewModelData);
-    }	
+    }
 
-	// Called when the node enters the scene tree for the first time.
-	public override void _Ready()
-	{
-		BindProperty("%TextEdit", "Text", "ViewModelData.Health", BindingMode.TwoWay);
-		base._Ready();
-	}
+    // Called when the node enters the scene tree for the first time.
+    public override void _Ready()
+    {
+        BindProperty("%TextEdit", "Text", "ViewModelData.Health", BindingMode.TwoWay);
+        GetNode<Button>("%Button").Pressed += () =>
+        {
+            this.QueueFree();
+        };
+        base._Ready();
+    }
 
-	// Called every frame. 'delta' is the elapsed time since the previous frame.
-	public override void _Process(double delta)
-	{
-	}
+    // Called every frame. 'delta' is the elapsed time since the previous frame.
+    public override void _Process(double delta)
+    {
+    }
 }

--- a/examples/basic-bindings/PlayerDataListItem.tscn
+++ b/examples/basic-bindings/PlayerDataListItem.tscn
@@ -20,5 +20,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Button" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "Remove"


### PR DESCRIPTION
Scenelist bindings can be specified with BindingMode.TwoWay to enable updates to the backling list when child scenes are removed